### PR TITLE
Add support for AMD CPUs

### DIFF
--- a/Include/ProcessorInfo.h
+++ b/Include/ProcessorInfo.h
@@ -135,6 +135,7 @@ enum {
 
 #define K8_FIDVID_STATUS   0xC0010042
 #define K10_COFVID_STATUS  0xC0010071
+#define K10_PSTATE_STATUS  0xC0010064
 
 #define CPU_MODEL_DOTHAN         0x0D  ///< Dothan
 #define CPU_MODEL_YONAH          0x0E  ///< Sossaman, Yonah

--- a/Library/OcCpuLib/OcCpuLib.c
+++ b/Library/OcCpuLib/OcCpuLib.c
@@ -679,15 +679,6 @@ ScanIntelProcessor (
   Cpu->TSCFrequency = GetPerformanceCounterProperties (NULL, NULL);
 
   if (Cpu->CPUFrequency == 0) {
-    DEBUG ((
-      DEBUG_INFO,
-      "%a %a %11lld %5dMHz\n",
-      "TSC",
-      "Frequency",
-      Cpu->TSCFrequency,
-      DivU64x32 (Cpu->TSCFrequency, 1000000)
-      ));
-
     //
     // There may be some quirks with virtual CPUs (VMware is fine).
     // Formerly we checked Cpu->MinBusRatio > 0, but we have no MinBusRatio on Penryn.
@@ -700,25 +691,6 @@ ScanIntelProcessor (
       Cpu->FSBFrequency = 100000000;
     }
   }
-
-  DEBUG ((
-    DEBUG_INFO,
-    "%a %a %11lld %5dMHz\n",
-    "CPU",
-    "Frequency",
-    Cpu->CPUFrequency,
-    DivU64x32 (Cpu->CPUFrequency, 1000000)
-    ));
-
-  DEBUG ((
-    DEBUG_INFO,
-    "%a %a %11lld %5dMHz\n",
-    "FSB",
-    "Frequency",
-    Cpu->FSBFrequency,
-    DivU64x32 (Cpu->FSBFrequency, 1000000)
-    ));
-
   //
   // Calculate number of cores
   //
@@ -759,14 +731,6 @@ ScanIntelProcessor (
   //
   // TODO: handle package count...
   //
-
-  DEBUG ((
-    DEBUG_INFO,
-    "Pkg %u Cores %u Threads %u\n",
-    Cpu->PackageCount,
-    Cpu->CoreCount,
-    Cpu->ThreadCount
-    ));
 }
 
 VOID
@@ -848,41 +812,6 @@ ScanAmdProcessor (
     }
     Cpu->FSBFrequency = DivU64x32 (Cpu->TSCFrequency, Cpu->MaxBusRatio);
   }
-
-  DEBUG ((
-    DEBUG_INFO,
-    "%a %a %11lld %5dMHz\n",
-    "TSC",
-    "Frequency",
-    Cpu->TSCFrequency,
-    DivU64x32 (Cpu->TSCFrequency, 1000000)
-    ));
-
-  DEBUG ((
-    DEBUG_INFO,
-    "%a %a %11lld %5dMHz\n",
-    "CPU",
-    "Frequency",
-    Cpu->CPUFrequency,
-    DivU64x32 (Cpu->CPUFrequency, 1000000)
-    ));
-
-  DEBUG ((
-    DEBUG_INFO,
-    "%a %a %11lld %5dMHz\n",
-    "FSB",
-    "Frequency",
-    Cpu->FSBFrequency,
-    DivU64x32 (Cpu->FSBFrequency, 1000000)
-    ));
-
-  DEBUG ((
-    DEBUG_INFO,
-    "Pkg %u Cores %u Threads %u\n",
-    Cpu->PackageCount,
-    Cpu->CoreCount,
-    Cpu->ThreadCount
-    ));
 }
 
 /** Scan the processor and fill the cpu info structure with results
@@ -1001,6 +930,41 @@ OcCpuScanProcessor (
     DEBUG ((DEBUG_WARN, "Found unsupported CPU vendor: %0X", Cpu->Vendor[0]));
     return;
   }
+
+  DEBUG ((
+    DEBUG_INFO,
+    "%a %a %11lld %5dMHz\n",
+    "TSC",
+    "Frequency",
+    Cpu->TSCFrequency,
+    DivU64x32 (Cpu->TSCFrequency, 1000000)
+    ));
+
+  DEBUG ((
+    DEBUG_INFO,
+    "%a %a %11lld %5dMHz\n",
+    "CPU",
+    "Frequency",
+    Cpu->CPUFrequency,
+    DivU64x32 (Cpu->CPUFrequency, 1000000)
+    ));
+
+  DEBUG ((
+    DEBUG_INFO,
+    "%a %a %11lld %5dMHz\n",
+    "FSB",
+    "Frequency",
+    Cpu->FSBFrequency,
+    DivU64x32 (Cpu->FSBFrequency, 1000000)
+    ));
+
+  DEBUG ((
+    DEBUG_INFO,
+    "Pkg %u Cores %u Threads %u\n",
+    Cpu->PackageCount,
+    Cpu->CoreCount,
+    Cpu->ThreadCount
+    ));
 }
 
 VOID


### PR DESCRIPTION
This PR has been tested on Ryzen (17h) and FX (15h). It hasn't been tested on A-Series CPUs (16h) yet, but since those share the exact same code as FX, that shouldn't be an issue. 

This still requires some modifications to OcTimerLib as the current implementation is broken ([this line](https://github.com/acidanthera/OcSupportPkg/blob/master/Library/OcTimerLib/OcTimerLib.c#L92) causes an assert), but @Download-Fritz wanted to take care of that