### PR TITLE
Add support for the Xeon Scaleable family

### DIFF
--- a/Library/OcCpuLib/OcCpuLib.c
+++ b/Library/OcCpuLib/OcCpuLib.c
@@ -100,6 +100,15 @@ DetectAppleMajorType (
       ++BrandInfix;
     }
 
+    // Support Xeon Scalable chips: Xeon(R) Gold 6136 CPU
+    if (AsciiStrnCmp (BrandInfix, "Bronze", L_STR_LEN ("Bronze")) == 0 ||
+        AsciiStrnCmp (BrandInfix, "Silver", L_STR_LEN ("Silver")) == 0 ||
+        AsciiStrnCmp (BrandInfix, "Gold", L_STR_LEN ("Gold")) == 0 ||
+        AsciiStrnCmp (BrandInfix, "Platinum", L_STR_LEN ("Platinum")) == 0) {
+      // Treat Xeon Scalable chips as their closest relatives, Xeon W
+      return AppleProcessorMajorXeonW;
+    }
+
     //
     // Support both variants: Xeon(R) E5-1234 and Xeon(R) CPU E5-1234
     //


### PR DESCRIPTION
These chips aren't available in any Macs to date but they are similar to the Xeon Ws used in the iMacPro1,1 and the upcoming MacPro7,1.