### PR TITLE
OcAppleKernelLib: Added patch for MSR MISC_PWR_MGMT (1AAh)

### DIFF
--- a/Include/ProcessorInfo.h
+++ b/Include/ProcessorInfo.h
@@ -63,6 +63,7 @@
 #define MSR_TEMPERATURE_TARGET            0x1A2
 #define MSR_MISC_PWR_MGMT                 0x1AA
 #define MISC_PWR_MGMT_EIST_HW_DIS         (1 << 0)
+#define MISC_PWR_MGMT_LOCK                (1 << 13)
 #define MAX_RATIO_LIMIT_8C_OFFSET         56
 #define MAX_RATIO_LIMIT_7C_OFFSET         48
 #define MAX_RATIO_LIMIT_6C_OFFSET         40

--- a/Library/OcAppleKernelLib/CommonPatches.c
+++ b/Library/OcAppleKernelLib/CommonPatches.c
@@ -394,7 +394,7 @@ PatchAppleXcpmExtraMsrs (
   //
   Status = PatcherApplyGenericPatch (Patcher, &mMiscPwrMgmtRelPatch);
   if (RETURN_ERROR (Status)) {
-    DEBUG ((DEBUG_WARN, "OCAK: Failed to patch writes to MSR_MISC_PWR_MGMT - %r, trying dbg\n", Status));
+    DEBUG ((DEBUG_INFO, "OCAK: Failed to patch writes to MSR_MISC_PWR_MGMT - %r, trying dbg\n", Status));
     Status = PatcherApplyGenericPatch (Patcher, &mMiscPwrMgmtDbgPatch);
   }
 

--- a/Library/OcAppleKernelLib/CommonPatches.c
+++ b/Library/OcAppleKernelLib/CommonPatches.c
@@ -368,18 +368,18 @@ PatchAppleXcpmExtraMsrs (
   //
   MiscPwrMgmt = AsmReadMsr64 (MSR_MISC_PWR_MGMT);
   if (MiscPwrMgmt & MISC_PWR_MGMT_LOCK) {
-    DEBUG ((DEBUG_INFO, "MSR_MISC_PWR_MGMT (%Lx) is locked; attempting to patch writes\n", MiscPwrMgmt));
+    DEBUG ((DEBUG_INFO, "OCAK: MSR_MISC_PWR_MGMT (%Lx) is locked; attempting to patch writes\n", MiscPwrMgmt));
     Status = PatcherApplyGenericPatch (
       Patcher,
       &mMiscPwrMgmtPatch
       );
     if (RETURN_ERROR (Status)) {
-      DEBUG ((DEBUG_WARN, "Failed to patch writes to MSR_MISC_PWR_MGMT: %r\n", Status));
+      DEBUG ((DEBUG_WARN, "OCAK: Failed to patch writes to MSR_MISC_PWR_MGMT: %r\n", Status));
     } else {
       ++ Replacements;
     }
   } else {
-    DEBUG ((DEBUG_INFO, "MSR_MISC_PWR_MGMT (%Lx) is unlocked\n", MiscPwrMgmt));
+    DEBUG ((DEBUG_INFO, "OCAK: MSR_MISC_PWR_MGMT (%Lx) is unlocked\n", MiscPwrMgmt));
   }
 
   return Replacements > 0 ? EFI_SUCCESS : EFI_NOT_FOUND;

--- a/Library/OcAppleKernelLib/CommonPatches.c
+++ b/Library/OcAppleKernelLib/CommonPatches.c
@@ -287,7 +287,7 @@ mMiscPwrMgmtRelPatch = {
   .Replace     = mMiscPwrMgmtRelReplace,
   .ReplaceMask = NULL,
   .Size        = sizeof (mMiscPwrMgmtRelFind),
-  .Count       = 4,
+  .Count       = 0,
   .Skip        = 0,
   .Limit       = 0
 };
@@ -308,15 +308,15 @@ mMiscPwrMgmtDbgReplace[] = {
 STATIC
 PATCHER_GENERIC_PATCH
 mMiscPwrMgmtDbgPatch = {
-  .Base        = "_xcpm_hwp_enable",
+  .Base        = NULL,
   .Find        = mMiscPwrMgmtDbgFind,
   .Mask        = NULL,
   .Replace     = mMiscPwrMgmtDbgReplace,
   .ReplaceMask = NULL,
   .Size        = sizeof (mMiscPwrMgmtDbgFind),
-  .Count       = 2,
+  .Count       = 0,
   .Skip        = 0,
-  .Limit       = 4096
+  .Limit       = 0
 };
 
 RETURN_STATUS
@@ -399,7 +399,8 @@ PatchAppleXcpmExtraMsrs (
   }
 
   if (!RETURN_ERROR (Status)) {
-    ++ Replacements;
+    DEBUG ((DEBUG_INFO, "OCAK: Patched writes to MSR_MISC_PWR_MGMT\n"));
+    ++Replacements;
   } else {
     DEBUG ((DEBUG_WARN, "OCAK: Failed to patch writes to MSR_MISC_PWR_MGMT - %r\n", Status));
   }


### PR DESCRIPTION
Patch kernel writes to MISC_PWR_MGMT (1AAh) if the system firmware has locked that register (flag `0x2000`).

This change allows Skylake-SP (Xeon Scalable) CPUs to boot with their native CPU ID rather than emulating an older chip. I suspect it will also work for Xeon W chips which share the same ID and capabilities.

I'm not sure if this should be part of `AppleXcpmExtraMsrs` or not but starting with it there based on @vit9696's suggestion. See acidanthera/bugtracker#365.

CCing @PMheart who I believe was involved in similar discussions working around issues with Xeon W, e.g. [this CPUID patch](https://www.insanelymac.com/forum/topic/338516-opencore-discussion/?page=5&tab=comments#comment-2671882).

[This discussion thread about Xeon Ws may also be relevant.](https://www.insanelymac.com/forum/topic/335193-help-installing-mojave-on-xeon-w-2175-and-asus-ws-c422-mobo/)