### PR TITLE
Add cpuid hypervisor support to work with virtualization

### DIFF
--- a/Include/Library/OcCpuLib.h
+++ b/Include/Library/OcCpuLib.h
@@ -67,7 +67,7 @@ typedef struct {
   UINT16                  PackageCount;
   UINT16                  CoreCount;
   UINT16                  ThreadCount;
-  BOOLEAN                   Hypervisor;
+  BOOLEAN                 Hypervisor;
 
   //
   // Platform-dependent frequency for the Always Running Timer (ART), normally

--- a/Include/Library/OcCpuLib.h
+++ b/Include/Library/OcCpuLib.h
@@ -37,6 +37,7 @@ typedef struct {
   CPUID_VERSION_INFO_EDX  CpuidVerEdx;
 
   UINT32                  MicrocodeRevision;
+  BOOLEAN                 Hypervisor;   //< indicate whether we are under virtualization
 
   UINT8                   Type;
   UINT8                   Family;
@@ -67,7 +68,6 @@ typedef struct {
   UINT16                  PackageCount;
   UINT16                  CoreCount;
   UINT16                  ThreadCount;
-  BOOLEAN                 Hypervisor;
 
   //
   // Platform-dependent frequency for the Always Running Timer (ART), normally

--- a/Include/Library/OcCpuLib.h
+++ b/Include/Library/OcCpuLib.h
@@ -67,6 +67,7 @@ typedef struct {
   UINT16                  PackageCount;
   UINT16                  CoreCount;
   UINT16                  ThreadCount;
+  BOOLEAN                   Hypervisor;
 
   //
   // Platform-dependent frequency for the Always Running Timer (ART), normally

--- a/Include/Library/OcCpuLib.h
+++ b/Include/Library/OcCpuLib.h
@@ -110,7 +110,7 @@ typedef struct {
   // The CPU frequency derived from the CPUID VMWare Timing leaf.
   // 0 if VMWare Timing leaf is not present.
   //
-  UINT64                  CPUFrequencyFromVMWare;
+  UINT64                  CPUFrequencyFromVMT;
 
   //
   // The Front Side Bus (FSB) frequency calculated from dividing the CPU

--- a/Include/Library/OcCpuLib.h
+++ b/Include/Library/OcCpuLib.h
@@ -105,6 +105,13 @@ typedef struct {
   //
   UINT64                  CPUFrequencyFromART;
 
+
+  //
+  // The CPU frequency derived from the CPUID VMWare Timing leaf.
+  // 0 if VMWare Timing leaf is not present.
+  //
+  UINT64                  CPUFrequencyFromVMWare;
+
   //
   // The Front Side Bus (FSB) frequency calculated from dividing the CPU
   // frequency by the Max Ratio.

--- a/Library/OcCpuLib/OcCpuLib.c
+++ b/Library/OcCpuLib/OcCpuLib.c
@@ -1008,7 +1008,7 @@ ScanIntelProcessor (
   // the information we want outside the function, skip anyway.
   // Things may be different in other hypervisors, but should work with QEMU/VMWare for now.
   //
-  if (!Cpu->CPUFrequencyFromVMWare){
+  if (Cpu->CPUFrequencyFromVMT == 0){
     //
     // TODO: this may not be accurate on some older processors.
     //
@@ -1190,7 +1190,7 @@ ScanAmdProcessor (
   //           both the operating and the nominal frequency, latter for
   //           the invariant TSC.
   //
-  if (!Cpu->CPUFrequencyFromVMWare){
+  if (Cpu->CPUFrequencyFromVMT == 0){
     Cpu->CPUFrequencyFromTSC = OcCalculateTSCFromPMTimer (Recalculate);
     Cpu->CPUFrequency = Cpu->CPUFrequencyFromTSC;
   }
@@ -1207,7 +1207,7 @@ ScanAmdProcessor (
 
     switch (Cpu->ExtFamily) {
       case AMD_CPU_EXT_FAMILY_17H:
-        if (!Cpu->CPUFrequencyFromVMWare){
+        if (Cpu->CPUFrequencyFromVMT == 0){
           CofVid           = AsmReadMsr64 (K10_PSTATE_STATUS);
           CoreFrequencyID  = BitFieldRead64 (CofVid, 0, 7);
           CoreDivisorID    = BitFieldRead64 (CofVid, 8, 13);
@@ -1227,7 +1227,7 @@ ScanAmdProcessor (
         break;
       case AMD_CPU_EXT_FAMILY_15H:
       case AMD_CPU_EXT_FAMILY_16H:
-        if (!Cpu->CPUFrequencyFromVMWare){
+        if (Cpu->CPUFrequencyFromVMT == 0){
           // FIXME: Please refer to FIXME(1) for the MSR used here.
           CofVid           = AsmReadMsr64 (K10_COFVID_STATUS);
           CoreFrequencyID  = BitFieldRead64 (CofVid, 0, 5);
@@ -1262,7 +1262,7 @@ ScanAmdProcessor (
     //
     // When under virtualization this information is already available to us.
     //
-    if (!Cpu->CPUFrequencyFromVMWare) { 
+    if (Cpu->CPUFrequencyFromVMT == 0) { 
       //
       // CPUPM is not supported on AMD, meaning the current
       // and minimum bus ratio are equal to the maximum bus ratio
@@ -1426,10 +1426,10 @@ OcCpuScanProcessor (
       //
       // We get kHZ from node and we should translate it first.
       //
-      Cpu->CPUFrequencyFromVMWare = CpuidEax * 1000;
+      Cpu->CPUFrequencyFromVMT = CpuidEax * 1000;
       Cpu->FSBFrequency = CpuidEbx * 1000;
 
-      Cpu->CPUFrequency = Cpu->CPUFrequencyFromVMWare;
+      Cpu->CPUFrequency = Cpu->CPUFrequencyFromVMT;
       //
       // We can caculate Bus Ratio here
       //

--- a/Library/OcCpuLib/OcCpuLib.c
+++ b/Library/OcCpuLib/OcCpuLib.c
@@ -1390,7 +1390,7 @@ OcCpuScanProcessor (
 
   DEBUG ((DEBUG_INFO, "OCCPU: %a %a\n", "Found", Cpu->BrandString));
 
-  DEBUG ((DEBUG_INFO, "OCCPU: Hypervisor: %a\n", Cpu->Hypervisor ? "Yes": "No"));
+  DEBUG ((DEBUG_INFO, "OCCPU: Hypervisor: %d\n", Cpu->Hypervisor));
 
   DEBUG ((
     DEBUG_INFO,


### PR DESCRIPTION
https://github.com/acidanthera/bugtracker/issues/531

For some reason that some msr not impletement in such hypervisor (QEMU/KVM/VMWare), so some logic may not work fine in a VM.
This commit will add cpuid hypervisor support to indicate whether we are
under virtualization, then we do some tricks to make it work.

According to these links:
    1. [CPUID usage for interaction between Hypervisors and Linux.](https://lwn.net/Articles/301888/)
    2. [[Qemu-devel] [PATCH v2 0/3] x86-kvm: Fix Mac guest timekeeping by exposi](https://lists.gnu.org/archive/html/qemu-devel/2017-01/msg04344.html)

There is a "VMWare Timing" Node located at 0x40000010 where we can get
TSC/FSB Frequency.It is more sensable than geting those freq from MSR which
most hypervisors not implemented yet (KVM/VMWare).