### PR TITLE
RsaTool: Fix OpenSSL 1.0.x compatibility

### DIFF
--- a/Utilities/RsaTool/openssl_compat.h
+++ b/Utilities/RsaTool/openssl_compat.h
@@ -21,7 +21,7 @@
 #include <openssl/pem.h>
 #include <openssl/rsa.h>
 
-#if !defined(HAVE_RSA_GET0_KEY) && defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x1000100fL
+#if !defined(HAVE_RSA_GET0_KEY) && defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
 #define HAVE_RSA_GET0_KEY
 #define HAVE_RSA_SET0_KEY
 #define EVP_MD_CTX_cleanup EVP_MD_CTX_free


### PR DESCRIPTION
RSA_get0_key/RSA_set0_key were introduced with OpenSSL 1.1.0, not 1.0.1.

Reported by @E-werd.