### PR TITLE
add Xeon E5(Broadwell-EP) support

### DIFF
--- a/Include/ProcessorInfo.h
+++ b/Include/ProcessorInfo.h
@@ -165,6 +165,7 @@ enum {
 #define CPU_MODEL_HASWELL_EP     0x3F  ///< Haswell MB
 #define CPU_MODEL_HASWELL_ULT    0x45  ///< Haswell ULT
 #define CPU_MODEL_BROADWELL      0x3D  ///< Broadwell
+#define CPU_MODEL_BROADWELL_EP   0x4F  ///< Broadwell_EP
 #define CPU_MODEL_BROADWELL_ULX  0x3D
 #define CPU_MODEL_BROADWELL_ULT  0x3D
 #define CPU_MODEL_BRYSTALWELL    0x47

--- a/Library/OcCpuLib/OcCpuLib.c
+++ b/Library/OcCpuLib/OcCpuLib.c
@@ -413,6 +413,7 @@ DetectAppleProcessorType (
     //   Pentium, Celeron
     //
     case CPU_MODEL_BROADWELL:     // 0x3D
+    case CPU_MODEL_BROADWELL_EP:  // 0x4F
     case CPU_MODEL_CRYSTALWELL:   // 0x46
     case CPU_MODEL_BRYSTALWELL:   // 0x47
       if (AppleMajorType == AppleProcessorMajorM) {
@@ -1579,6 +1580,7 @@ OcCpuModelToAppleFamily (
     case CPU_MODEL_CRYSTALWELL:
       return CPUFAMILY_INTEL_HASWELL;
     case CPU_MODEL_BROADWELL:
+    case CPU_MODEL_BROADWELL_EP:
     case CPU_MODEL_BRYSTALWELL:
       return CPUFAMILY_INTEL_BROADWELL;
     case CPU_MODEL_SKYLAKE:


### PR DESCRIPTION
 fix unknown cpu type in Apple system profiler

Fix issue [#585](https://github.com/acidanthera/bugtracker/issues/585)
00:041 00:008 OCCPU: Detected Apple Processor Type: 0A -> 0A01
Return the correct Processor Type: 0A01

[opencore-2019-11-28-013439.txt](https://github.com/acidanthera/OcSupportPkg/files/3899483/opencore-2019-11-28-013439.txt)
