### PR TITLE
OcCpuLib: Minor logging changes

### DIFF
--- a/Include/Library/OcCpuLib.h
+++ b/Include/Library/OcCpuLib.h
@@ -118,6 +118,22 @@ typedef struct {
   UINT64                  FSBFrequency;
 } OC_CPU_INFO;
 
+typedef enum {
+  OcCpuGenerationUnknown,
+  OcCpuGenerationPenryn,
+  OcCpuGenerationNehalem,
+  OcCpuGenerationWestmere,
+  OcCpuGenerationSandyBridge,
+  OcCpuGenerationIvyBridge,
+  OcCpuGenerationHaswell,
+  OcCpuGenerationBroadwell,
+  OcCpuGenerationSkylake,
+  OcCpuGenerationKabyLake,
+  OcCpuGenerationCoffeeLake,
+  OcCpuGenerationCannonLake,
+  OcCpuGenerationMaxGeneration
+} OC_CPU_GENERATION;
+
 /**
   Scan the processor and fill the cpu info structure with results.
 
@@ -154,12 +170,12 @@ OcCpuModelToAppleFamily (
   );
 
 /**
-  Special Intel Sandy Bridge and Ivy Bridge detection code.
+  Obtain CPU's generation.
 
-  @retval TRUE when running with Sandy Bridge or Ivy Bridge CPU.
-**/
-BOOLEAN
-OcIsSandyOrIvy (
+  @retval CPU's generation (e.g. OcCpuGenerationUnknown).
+ */
+OC_CPU_GENERATION
+OcCpuGetGeneration (
   VOID
   );
 

--- a/Library/OcAppleBootCompatLib/CustomSlide.c
+++ b/Library/OcAppleBootCompatLib/CustomSlide.c
@@ -240,6 +240,7 @@ ShouldUseCustomSlideOffset (
   EFI_STATUS             Status;
   UINTN                  DescriptorSize;
   UINT32                 DescriptorVersion;
+  OC_CPU_GENERATION      CpuGeneration;
   UINTN                  Index;
   UINTN                  Slide;
   UINTN                  NumEntries;
@@ -279,7 +280,10 @@ ShouldUseCustomSlideOffset (
     FilterMap (FilterMapContext, MemoryMapSize, MemoryMap, DescriptorSize);
   }
 
-  SlideSupport->HasSandyOrIvy       = OcIsSandyOrIvy ();
+  CpuGeneration = OcCpuGetGeneration ();
+  SlideSupport->HasSandyOrIvy = CpuGeneration == OcCpuGenerationSandyBridge ||
+                                CpuGeneration == OcCpuGenerationIvyBridge;
+
   SlideSupport->EstimatedKernelArea = (UINTN) EFI_PAGES_TO_SIZE (
     CountRuntimePages (MemoryMapSize, MemoryMap, DescriptorSize, NULL)
     ) + ESTIMATED_KERNEL_SIZE;
@@ -824,6 +828,7 @@ AppleSlideHandleBalloonState (
   UINTN                  StartAddrTmp;
   UINTN                  EndAddr;
   UINT32                 DescriptorVersion;
+  OC_CPU_GENERATION      CpuGeneration;
   BOOLEAN                HasSandyOrIvy;
   UINTN                  EstimatedKernelArea;
 
@@ -864,7 +869,10 @@ AppleSlideHandleBalloonState (
     return EFI_OUT_OF_RESOURCES;
   }
 
-  HasSandyOrIvy       = OcIsSandyOrIvy ();
+  CpuGeneration       = OcCpuGetGeneration ();
+  HasSandyOrIvy       = CpuGeneration == OcCpuGenerationSandyBridge ||
+                        CpuGeneration == OcCpuGenerationIvyBridge;
+
   EstimatedKernelArea = (UINTN) EFI_PAGES_TO_SIZE (
     CountRuntimePages (MemoryMapSize, MemoryMap, DescriptorSize, NULL)
     ) + ESTIMATED_KERNEL_SIZE;

--- a/Library/OcCpuLib/OcCpuLib.c
+++ b/Library/OcCpuLib/OcCpuLib.c
@@ -283,6 +283,7 @@ ScanIntelProcessor (
   MSR_SANDY_BRIDGE_PKG_CST_CONFIG_CONTROL_REGISTER  PkgCstConfigControl;
   MSR_IA32_PERF_STATUS_REGISTER                     PerfStatus;
   MSR_NEHALEM_PLATFORM_INFO_REGISTER                PlatformInfo;
+  OC_CPU_GENERATION                                 CpuGeneration;
   MSR_NEHALEM_TURBO_RATIO_LIMIT_REGISTER            TurboLimit;
   UINT16                                            CoreCount;
   CONST CHAR8                                       *TimerSourceType;
@@ -315,10 +316,17 @@ ScanIntelProcessor (
     //
     if (Cpu->Model >= CPU_MODEL_NEHALEM) {
       PerfStatus.Uint64 = AsmReadMsr64 (MSR_IA32_PERF_STATUS);
-      Cpu->CurBusRatio = (UINT8) (PerfStatus.Bits.State >> 8U);
       PlatformInfo.Uint64 = AsmReadMsr64 (MSR_NEHALEM_PLATFORM_INFO);
       Cpu->MinBusRatio = (UINT8) PlatformInfo.Bits.MaximumEfficiencyRatio;
       Cpu->MaxBusRatio = (UINT8) PlatformInfo.Bits.MaximumNonTurboRatio;
+      CpuGeneration = OcCpuGetGeneration ();
+
+      if (CpuGeneration == OcCpuGenerationNehalem
+        || CpuGeneration == OcCpuGenerationWestmere) {
+        Cpu->CurBusRatio = (UINT8) PerfStatus.Bits.State;
+      } else {
+        Cpu->CurBusRatio = (UINT8) (PerfStatus.Bits.State >> 8U);
+      }
     } else if (Cpu->Model >= CPU_MODEL_PENRYN) {
       PerfStatus.Uint64 = AsmReadMsr64 (MSR_IA32_PERF_STATUS);
       Cpu->MaxBusRatio = (UINT8) (RShiftU64 (PerfStatus.Uint64, 8) & 0x1FU);

--- a/Library/OcCpuLib/OcCpuLib.c
+++ b/Library/OcCpuLib/OcCpuLib.c
@@ -846,15 +846,15 @@ OcCpuCorrectFlexRatio (
   }
 }
 
-BOOLEAN
-OcIsSandyOrIvy (
+OC_CPU_GENERATION
+OcCpuGetGeneration (
   VOID
   )
 {
   CPU_MICROCODE_PROCESSOR_SIGNATURE  Sig;
-  BOOLEAN                            SandyOrIvy;
   UINT32                             CpuFamily;
   UINT32                             CpuModel;
+  OC_CPU_GENERATION                  CpuGeneration;
 
   Sig.Uint32 = 0;
 
@@ -870,15 +870,72 @@ OcIsSandyOrIvy (
     CpuModel |= Sig.Bits.ExtendedModel << 4;
   }
 
-  SandyOrIvy = CpuFamily == 6 && (CpuModel == 0x2A || CpuModel == 0x3A);
+  CpuGeneration = OcCpuGenerationUnknown;
+  if (CpuFamily == 6) {
+    switch (CpuModel) {
+      case CPU_MODEL_PENRYN:
+        CpuGeneration = OcCpuGenerationPenryn;
+        break;
+      case CPU_MODEL_NEHALEM:
+      case CPU_MODEL_FIELDS:
+      case CPU_MODEL_DALES:
+      case CPU_MODEL_NEHALEM_EX:
+        CpuGeneration = OcCpuGenerationNehalem;
+        break;
+      case CPU_MODEL_DALES_32NM:
+      case CPU_MODEL_WESTMERE:
+      case CPU_MODEL_WESTMERE_EX:
+        CpuGeneration = OcCpuGenerationWestmere;
+        break;
+      case CPU_MODEL_SANDYBRIDGE:
+      case CPU_MODEL_JAKETOWN:
+        CpuGeneration = OcCpuGenerationSandyBridge;
+        break;
+      case CPU_MODEL_IVYBRIDGE:
+      case CPU_MODEL_IVYBRIDGE_EP:
+        CpuGeneration = OcCpuGenerationIvyBridge;
+        break;
+      case CPU_MODEL_HASWELL:
+      case CPU_MODEL_HASWELL_EP:
+      case CPU_MODEL_HASWELL_ULT:
+      case CPU_MODEL_CRYSTALWELL:
+        CpuGeneration = OcCpuGenerationHaswell;
+        break;
+      case CPU_MODEL_BROADWELL:
+      case CPU_MODEL_BROADWELL_EP:
+      case CPU_MODEL_BRYSTALWELL:
+        CpuGeneration = OcCpuGenerationBroadwell;
+        break;
+      case CPU_MODEL_SKYLAKE:
+      case CPU_MODEL_SKYLAKE_DT:
+      case CPU_MODEL_SKYLAKE_W:
+        CpuGeneration = OcCpuGenerationSkylake;
+        break;
+      case CPU_MODEL_KABYLAKE:
+      case CPU_MODEL_KABYLAKE_DT:
+        //
+        // Kaby has 0x9 stepping, and Coffee use 0xA / 0xB stepping.
+        //
+        if (Sig.Bits.Stepping == 9) {
+          CpuGeneration = OcCpuGenerationKabyLake;
+        } else {
+          CpuGeneration = OcCpuGenerationCoffeeLake;
+        }
+        break;
+      case CPU_MODEL_CANNONLAKE:
+        CpuGeneration = OcCpuGenerationCannonLake;
+        break;
+    }
+  }
 
   DEBUG ((
     DEBUG_VERBOSE,
-    "OCCPU: Discovered CpuFamily %d CpuModel %d SandyOrIvy %a\n",
+    "OCCPU: Discovered CpuFamily %d CpuModel %d CpuStepping %d CpuGeneration %d\n",
     CpuFamily,
     CpuModel,
-    SandyOrIvy ? "YES" : "NO"
+    Sig.Bits.Stepping,
+    CpuGeneration
     ));
 
-  return SandyOrIvy;
+  return CpuGeneration;
 }

--- a/Library/OcCpuLib/OcCpuLib.inf
+++ b/Library/OcCpuLib/OcCpuLib.inf
@@ -24,7 +24,7 @@
   VERSION_STRING  = 1.0
   LIBRARY_CLASS   = OcCpuLib|PEIM DXE_DRIVER DXE_RUNTIME_DRIVER UEFI_DRIVER UEFI_APPLICATION DXE_SMM_DRIVER
 
-# VALID_ARCHITECTURES = IA32 X64 
+# VALID_ARCHITECTURES = IA32 X64
 
 [Packages]
   OcSupportPkg/OcSupportPkg.dec
@@ -39,6 +39,7 @@
 
 [Protocols]
   gEfiMpServiceProtocolGuid
+  gFrameworkEfiMpServiceProtocolGuid
 
 [Sources]
   AppleCpuSupport.c


### PR DESCRIPTION
 - Fall back to framework EFI MP services for retrieving package/core/thread count if UEFI MP services are not available (depends on https://github.com/acidanthera/EfiPkg/pull/4)
 - Fix current bus ratio calculation on Nehalem/Westmere (and likely other related CPUs, though this is untested on them)